### PR TITLE
gpg key updated to support debian 11

### DIFF
--- a/proxmox/proxmox.yml
+++ b/proxmox/proxmox.yml
@@ -75,7 +75,7 @@
 
   - name: Add prox apt signing key
     apt_key:
-      url: http://download.proxmox.com/debian/proxmox-ve-release-6.x.gpg
+      url: https://enterprise.proxmox.com/debian/proxmox-release-bullseye.gpg
       state: present
 
   - name: add prox repo


### PR DESCRIPTION
https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_11_Bullseye#Install_Proxmox_VE

https://enterprise.proxmox.com/debian/proxmox-release-bullseye.gpg